### PR TITLE
Truncate file while saving

### DIFF
--- a/debian/control/control.go
+++ b/debian/control/control.go
@@ -43,7 +43,7 @@ func (c Control) Write(w io.Writer) error {
 
 // WriteFile will write the control file to the given filename
 func (c Control) WriteFile(fn string) error {
-	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0755)
+	f, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}

--- a/debian/control/control_test.go
+++ b/debian/control/control_test.go
@@ -46,7 +46,7 @@ Description: This is a description
 `
 
 		Convey("when it is parsed", func() {
-			ctrl, err := Parse(s)
+			ctrl, err := Parse([]byte(s))
 			So(err, ShouldBeNil)
 
 			Convey("it should contain the long description", func() {


### PR DESCRIPTION
Hi Rob,
Without os.O_TRUNC I'm getting invalid control file after save. When newly created file is smaller than initial file.