### PR TITLE
Includes file with .ianinclude

### DIFF
--- a/ignore.go
+++ b/ignore.go
@@ -40,26 +40,63 @@ func (p *Pkg) IgnoreFile() string {
 	return p.Dir(".ianignore")
 }
 
+// IncludeFile returns the path to the packages include file
+func (p *Pkg) IncludeFile() string {
+	return p.Dir(".ianinclude")
+}
+
+// IncludeList returns the include patterns from the .ianinclude file.
+// If there is no include file then an empty slice is returned.
+func (p *Pkg) IncludeList() []string {
+	data, err := ioutil.ReadFile(p.IncludeFile())
+	if err != nil {
+		return []string{}
+	}
+
+	return str.CleanStrings(str.Lines(string(data)))
+}
+
 // Excludes provides things in the repo to be excluded from the package
 func (p *Pkg) Excludes() []string {
 	exc := p.IgnoreList()
 	exc = append(exc, []string{
-		".git", "pkg", ".gitignore", ".ianpush", ".ianignore", ".gitkeep",
+		".git", "pkg", ".gitignore", ".ianpush", ".ianignore", ".ianinclude", ".gitkeep",
 	}...)
 
 	return exc
 }
 
-// ListFiles returns the list of files that would be included in the package,
-// using rsync --list-only with the same exclude rules as the actual build.
-func (p *Pkg) ListFiles() ([]string, error) {
-	args := []string{"-rav", "--list-only"}
+// FilterArgs returns the ordered rsync filter arguments: includes first, then excludes.
+// If includes are specified, everything not explicitly included is also excluded.
+func (p *Pkg) FilterArgs() []string {
+	var args []string
+
+	includes := p.IncludeList()
+	for _, s := range includes {
+		if s == "" {
+			continue
+		}
+		args = append(args, fmt.Sprintf("--include=%s", s))
+	}
+	if len(includes) > 0 {
+		args = append(args, "--exclude=*")
+	}
+
 	for _, s := range p.Excludes() {
 		if s == "" {
 			continue
 		}
 		args = append(args, fmt.Sprintf("--exclude=%s", s))
 	}
+
+	return args
+}
+
+// ListFiles returns the list of files that would be included in the package,
+// using rsync --list-only with the same exclude rules as the actual build.
+func (p *Pkg) ListFiles() ([]string, error) {
+	args := []string{"-rav", "--list-only"}
+	args = append(args, p.FilterArgs()...)
 	args = append(args, p.Dir()+"/")
 
 	var out bytes.Buffer

--- a/packager.go
+++ b/packager.go
@@ -211,12 +211,7 @@ var StageFiles = func(br *BuildRequest) error {
 	}
 
 	args := []string{"-rav"}
-	for _, s := range br.pkg.Excludes() {
-		if s == "" {
-			continue
-		}
-		args = append(args, fmt.Sprintf("--exclude=%s", s))
-	}
+	args = append(args, br.pkg.FilterArgs()...)
 	args = append(args, br.pkg.Dir()+"/", br.tmp)
 
 	cmd := exec.Command("/usr/bin/rsync", args...)


### PR DESCRIPTION
I had claude make this but I don't understand its implications yet, not sure if it fits exactly what I was thinking... will need to look into it further.

  - Added IncludeFile() and IncludeList() methods mirroring the ignore equivalents
  - Added .ianinclude to the default excludes list (so the file itself never ends up in the package)
  - Added FilterArgs() which emits --include=... args first, then --exclude=...; if any includes are
  present it also appends --exclude=* so only explicitly included files get through
  - Updated both ListFiles() and StageFiles to use FilterArgs() instead of building exclude args inline

rsync processes filter rules in order and stops at the first match. So given:

  --include=usr/bin/myapp
  --exclude=*

  usr/bin/myapp matches the include and is kept. Everything else hits --exclude=* and is dropped.

  Without the --exclude=* at the end, the includes do nothing useful — files not matched by any include
  would just fall through to the existing excludes (.git, pkg, etc), and everything else would still be
  copied. The includes would only matter if a file happened to be listed in both .ianinclude and
  .ianignore.

  So the --exclude=* is what gives .ianinclude its "whitelist" semantics — it acts as a catch-all deny at
   the end of the include rules, before the specific excludes even run.

  One thing worth noting: rsync's include/exclude rules apply per path component, so to include
  usr/bin/myapp you may also need --include=usr/ and --include=usr/bin/ or rsync will exclude the parent
  directories before it ever reaches the file. Something to keep in mind when testing it out.